### PR TITLE
Rename script from openadmet to openadmet-toolkit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ test = [
 ]
 
 [project.scripts]
-openadmet = "openadmet.toolkit.cli.cli:cli"
+openadmet-toolkit = "openadmet.toolkit.cli.cli:cli"
 
 [tool.setuptools]
 # This subkey is a beta stage development and keys may change in the future, see https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html for more details


### PR DESCRIPTION
Clash with `openadmet-models` CLI


## Developers certificate of origin
- [X] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
